### PR TITLE
fix(validate-profiles): repair dead industry-cert-count check

### DIFF
--- a/scripts/validate-profiles.ps1
+++ b/scripts/validate-profiles.ps1
@@ -149,12 +149,14 @@ if ($startDate -and $startDate -ne "null") {
 }
 
 # --- Industry certification count check ---
-# Count badges in the Industry Certifications section (between markers)
-$certSection = [regex]::Match($readme, "Industry Certifications.*?</div>", [System.Text.RegularExpressions.RegexOptions]::Singleline)
+# Count badges in the Industry Certifications subsection only (heading up to the
+# next #### subheading), not the whole Credly block which also holds Professional
+# and Knowledge badges.
+$certSection = [regex]::Match($readme, "Industry Certifications.*?(?=\r?\n####|<!-- CREDLY-BADGES:END)", [System.Text.RegularExpressions.RegexOptions]::Singleline)
 if ($certSection.Success) {
     $certBadgeCount = ([regex]::Matches($certSection.Value, '<a href="https://www.credly.com/badges/')).Count
-    # Check if the shield badge in the header matches
-    if ($readme -match "AWS-(\d+)\%20Industry\%20Certs") {
+    # Header badge format is "Certified-6x%20AWS%2FTerraform".
+    if ($readme -match "Certified-(\d+)x\%20AWS") {
         $headerCertCount = [int]$Matches[1]
         if ($headerCertCount -ne $certBadgeCount) {
             $issues += "⚠️  Header badge says $headerCertCount industry certs but Credly section has $certBadgeCount"


### PR DESCRIPTION
## What

The profile validator's industry-certification-count check was silently a no-op and would have false-positived if it ran. Two bugs:

1. **Header regex never matched.** It looked for `AWS-(\d+)%20Industry%20Certs`, but the header badge was changed to `Certified-6x%20AWS%2FTerraform` (v4.1.0). The inner `if ($readme -match ...)` was always false -> the count comparison never executed. The check gave false confidence that it was validating cert counts.
2. **Section-span regex over-greedy.** `Industry Certifications.*?</div>` with Singleline ran past the `<!-- CREDLY-BADGES:END -->` marker to the next `</div>`, capturing all **18** Credly badges (Industry + Professional + Knowledge) instead of the **6** in the Industry block. So even with bug 1 fixed, it would report a false "6 vs 18" mismatch.

## Fix

- Scope the span to the Industry subsection only: heading up to the next `####` subheading or the END marker.
- Match the current header format `Certified-(\d+)x%20AWS`.

## Testing

Ran both regexes against the live README.md via PowerShell:
- Industry section badge count -> **6**
- Header cert count parsed -> **6**

They match, so the check now passes correctly and will catch a genuine future drift (e.g. adding a 7th cert badge without bumping the header).

Found during a full profile-repo audit (links, badges, scripts, workflows all checked).